### PR TITLE
Fixed Java installation bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,20 +27,9 @@ ENV PATH $PATH:$JAVA_HOME/bin
 # docker hardcoded sh...
 SHELL ["/bin/bash", "-c"]
 
-# install proper tools
+# install proper tools & java
 RUN apt-get update && \
-    apt-get install -y wget curl net-tools sudo
-
-# install oracle jave
-RUN cd /opt && \
-    wget -c --header 'Cookie: oraclelicense=accept-securebackup-cookie' http://download.oracle.com/otn-pub/java/jdk/10.0.2+13/19aef61b38124481863b1413dce1855f/jdk-10.0.2_linux-x64_bin.tar.gz && \
-    tar xvf jdk-10.0.2_linux-x64_bin.tar.gz && \
-    cd jdk-10.0.2 && \
-    source /etc/bash.bashrc && \
-    sudo update-alternatives --install '/usr/bin/java' 'java' '/opt/jdk-10.0.2/bin/java' 1 && \
-    sudo update-alternatives --install '/usr/bin/javac' 'javac' '/opt/jdk-10.0.2/bin/javac' 1 && \
-    sudo update-alternatives --set 'java' '/opt/jdk-10.0.2/bin/java' && \
-    sudo update-alternatives --set 'javac' '/opt/jdk-10.0.2/bin/javac'
+    apt-get install -y wget curl net-tools sudo default-jdk
 
 # install CobaltStrike with license key and update
 RUN var=$(curl 'https://www.cobaltstrike.com/download' -XPOST -H 'Referer: https://www.cobaltstrike.com/download' -H 'Content-Type: application/x-www-form-urlencoded' -H 'Origin: https://www.cobaltstrike.com' -H 'Host: www.cobaltstrike.com' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' -H 'Connection: keep-alive' -H 'Accept-Language: en-us' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/604.3.5 (KHTML, like Gecko) Version/11.0.1 Safari/604.3.5' --data "dlkey=$cs_key" | sed -n 's/.*href="\([^"]*\).*/\1/p' | grep /downloads/ | cut -d '.' -f 1) && \


### PR DESCRIPTION
When building a bug occurs where it cannot install Java from Oracle.

I have modified this to just use the repository java, which works great. 